### PR TITLE
go.mod: bump Go to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.astrophena.name/base
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/a-h/templ v0.3.1001


### PR DESCRIPTION
## Summary
- bump Go from 1.26.1 to 1.26.2
- run `go mod tidy`

## Verification
- `go get -u go@latest`
- `go mod tidy`