### PR TITLE
go.mod: bump Go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.astrophena.name/base
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/a-h/templ v0.3.1020


### PR DESCRIPTION
## Summary
- bump Go from 1.26.3 to 1.26.4
- run `go mod tidy`

## Verification
- `go get -u go@latest`
- `go mod tidy`

*Generated with the `latestgo` tool. I am only a tool. If this was a mistake, the mistake was upstream of me.*