### PR TITLE
devtools/deploy: make artifact chunk uploads replayable

### DIFF
--- a/devtools/deploy/main.go
+++ b/devtools/deploy/main.go
@@ -401,24 +401,27 @@ func uploadArtifactChunkAttempt(ctx context.Context, client *http.Client, token,
 	go monitorArtifactChunkUploadProgress(uploadCtx, cancelUpload, stallTimeout, progress, done)
 	defer finishUpload()
 
-	body := &artifactUploadProgressReader{
-		r: bytes.NewReader(data),
-		onProgress: func() {
-			if usesNetworkProgress(client) {
-				return
-			}
-			select {
-			case progress <- struct{}{}:
-			default:
-			}
-		},
-		onDone: finishUpload,
+	newBody := func() io.ReadCloser {
+		return io.NopCloser(&artifactUploadProgressReader{
+			r: bytes.NewReader(data),
+			onProgress: func() {
+				if usesNetworkProgress(client) {
+					return
+				}
+				select {
+				case progress <- struct{}{}:
+				default:
+				}
+			},
+			onDone: finishUpload,
+		})
 	}
-	req, err := http.NewRequestWithContext(uploadCtx, http.MethodPut, chunkURL, body)
+	req, err := http.NewRequestWithContext(uploadCtx, http.MethodPut, chunkURL, newBody())
 	if err != nil {
 		return err
 	}
 	req.ContentLength = int64(len(data))
+	req.GetBody = func() (io.ReadCloser, error) { return newBody(), nil }
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("User-Agent", version.UserAgent())

--- a/devtools/deploy/main_test.go
+++ b/devtools/deploy/main_test.go
@@ -243,6 +243,42 @@ func TestRunArtifactDeploymentUsesUploadToken(t *testing.T) {
 	}
 }
 
+func TestUploadArtifactChunkAttemptProvidesReplayableBody(t *testing.T) {
+	data := []byte("artifact chunk")
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.GetBody == nil {
+			t.Fatal("GetBody is nil")
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if !bytes.Equal(body, data) {
+			t.Fatalf("request body = %q, want %q", body, data)
+		}
+
+		replayedBody, err := r.GetBody()
+		if err != nil {
+			t.Fatalf("GetBody: %v", err)
+		}
+		defer replayedBody.Close()
+		replayed, err := io.ReadAll(replayedBody)
+		if err != nil {
+			t.Fatalf("read replayed body: %v", err)
+		}
+		if !bytes.Equal(replayed, data) {
+			t.Fatalf("replayed body = %q, want %q", replayed, data)
+		}
+
+		return jsonResponse(t, http.StatusOK, `{"status":"success"}`), nil
+	})}
+
+	chunk := artifactManifestChunk{Index: 0, Size: int64(len(data)), SHA256: "sha"}
+	if err := uploadArtifactChunkAttempt(context.Background(), client, "token", "https://deploy.test/chunk", chunk, data); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestUploadArtifactFileChunksRetriesTemporaryNetworkError(t *testing.T) {
 	dir := t.TempDir()
 	artifactPath := filepath.Join(dir, "rootfs.erofs")


### PR DESCRIPTION
### Motivation
- HTTP/2 transports can fail to retry requests after the request body has been written unless `Request.GetBody` is provided, causing errors like `define Request.GetBody to avoid this error` during artifact chunk uploads. 
- Make chunk upload requests replayable so the HTTP transport can safely retry transient failures and stalled uploads.

### Description
- Provide a replayable request body by creating a `newBody` factory that returns an `io.ReadCloser` wrapping `artifactUploadProgressReader` and set `req.GetBody` to return `newBody()` in `uploadArtifactChunkAttempt` (file `devtools/deploy/main.go`).
- Use `newBody()` as the initial request body when constructing the `http.Request` to ensure the same data can be produced again for retries (file `devtools/deploy/main.go`).
- Add `TestUploadArtifactChunkAttemptProvidesReplayableBody` to assert `Request.GetBody` is present and that the replayed body matches the original payload byte-for-byte (file `devtools/deploy/main_test.go`).

### Testing
- Ran `go test ./devtools/deploy`, and the tests passed (`ok   go.astrophena.name/base/devtools/deploy`).
- Ran `git diff --check` to ensure no whitespace issues, and it produced no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a285a7b8fcc832f925136de7f952ed0)