### PR TITLE
cli: convert time.Duration to string in JSON logs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -305,10 +305,20 @@ func newLogger(w io.Writer, level *slog.LevelVar) *logger.Logger {
 	if f, ok := w.(*os.File); ok && IsTerminal(int(f.Fd())) {
 		handler = tint.NewHandler(w, opts)
 	} else {
-		handler = slog.NewJSONHandler(w, &slog.HandlerOptions{Level: l.Level})
+		handler = slog.NewJSONHandler(w, &slog.HandlerOptions{
+			Level:       l.Level,
+			ReplaceAttr: replaceTimeDuration,
+		})
 	}
 	l.Attach(handler)
 	return l
+}
+
+func replaceTimeDuration(groups []string, attr slog.Attr) slog.Attr {
+	if attr.Value.Kind() != slog.KindDuration {
+		return attr
+	}
+	return slog.String(attr.Key, attr.Value.Duration().String())
 }
 
 // IsTerminal reports whether the file descriptor is connected to a terminal.
@@ -380,7 +390,8 @@ func parseDocComment() string {
 			break
 		}
 		if inComment {
-			doc.WriteString(line + "\n")
+			doc.WriteString(line)
+			doc.WriteString("\n")
 		}
 	}
 	if err := s.Err(); err != nil {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -11,13 +11,16 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"go.astrophena.name/base/cli"
+	"go.astrophena.name/base/logger"
 	"go.astrophena.name/base/testutil"
 	"go.astrophena.name/base/version"
 )
@@ -100,6 +103,12 @@ func (a *appWithVersionFlag) Run(ctx context.Context) error {
 	}
 	return nil
 }
+
+// durationLoggingApp tests time.Duration replacement by string in JSON logs.
+var durationLoggingApp = cli.AppFunc(func(ctx context.Context) error {
+	logger.Info(ctx, "reticulating splines", slog.Duration("duration", 5*time.Second))
+	return nil
+})
 
 func TestRun(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
@@ -228,6 +237,18 @@ func TestRun(t *testing.T) {
 				t.Errorf("error must be about creating cpu profile, got: %v", err)
 			}
 		})
+	})
+
+	t.Run("time.Duration is converted to string in JSON logs", func(t *testing.T) {
+		_, stderr, err := runTest(t, durationLoggingApp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantInStderr := `"duration":"5s"`
+		if !strings.Contains(stderr, wantInStderr) {
+			t.Errorf("want %s in stderr, got %s", wantInStderr, stderr)
+		}
 	})
 }
 


### PR DESCRIPTION
Before:

{"time":"2026-06-21T10:42:21.053175878Z","level":"INFO","msg":"reticulating splines","duration":5000000000}

After:

{"time":"2026-06-21T10:41:57.13551684Z","level":"INFO","msg":"reticulating splines","duration":"5s"}
